### PR TITLE
fix:Added non-trivial timezone test cases for v1.2.0 and fixed parsing func

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -129,6 +129,7 @@ def test_can_parse_comment_from_version_1_0_1(
     config=st.builds(
         Config1_2_0,
         gain=st.integers(0, 4),
+        timezone=st.integers(-12, 12),
     ),
 )
 def test_can_parse_comment_from_version_1_2_0(


### PR DESCRIPTION
Changes:

1. Made sure hypothesis is testing different timezone configurations when generating comments for firmware version 1.2.0.
2. Changed the regular expression for parsing comments from version 1.2.0 to include parsing the UTC-offset.